### PR TITLE
Add typescript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'short-uuid' {
-  function shortUuid(alphabet?:string): shortUuid.Translator;
+  function shortUuid(alphabet?: string): shortUuid.Translator;
 
   namespace shortUuid {
     export const constants: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+declare module 'short-uuid' {
+  function shortUuid(alphabet?:string): shortUuid.Translator;
+
+  namespace shortUuid {
+    export const constants: {
+      flickrBase58: string;
+      cookieBase90: string;
+    }
+
+    /** Generate a new regular UUID. */
+    export function uuid(): string;
+
+    export interface Translator {
+      /** The alphabet used for encoding UUIDs. */
+      alphabet: string;
+
+      /** Generate a new short UUID using this translator's alphabet. */
+      new: () => string;
+
+      /** Generate a new regular UUID. */
+      uuid(): string;
+
+      /** short -> long */
+      toUUID(shortId: string): string;
+
+      /** long -> short */
+      fromUUID(regularUUID: string): string;
+    }
+  }
+
+  export = shortUuid;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'short-uuid' {
-  function shortUuid(alphabet?: string): shortUuid.Translator;
+  function shortUUID(alphabet?: string): shortUUID.Translator;
 
-  namespace shortUuid {
+  namespace shortUUID {
     export const constants: {
       flickrBase58: string;
       cookieBase90: string;
@@ -28,5 +28,5 @@ declare module 'short-uuid' {
     }
   }
 
-  export = shortUuid;
+  export = shortUUID;
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.1",
   "description": "Create and translate standard UUIDs with shorter formats.",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "snyk test && grunt test",
     "cover": "grunt cover",


### PR DESCRIPTION
Tested with this code (modified from the README example) and run in `ts-node`

```ts
import * as short from 'short-uuid';

const translator = short(); // Defaults to flickrBase58
const decimalTranslator = short("0123456789"); // Provide a specific alphabet for translation
const cookieTranslator = short(short.constants.cookieBase90); // Use a constant for translation

// Generate a shortened v4 UUID
const shortId = translator.new();
console.log(shortId);

// Generate plain UUIDs
short.uuid(); // From the constructor without creating a translator
const regularUUID = translator.uuid(); // Each translator provides the uuid.v4() function

console.log(regularUUID);

// Translate UUIDs
console.log(translator.toUUID(shortId));
console.log(translator.fromUUID(regularUUID));

// See the alphabet used by a translator
console.log(translator.alphabet)

// View the constants
console.log(short.constants.flickrBase58);
console.log(short.constants.cookieBase90);

```

```
aturek@aturek-mbpro ~/ts-test> ts-node test.ts
3VKVopMcKshJStybhFzXtb
a610f20d-f03f-45fc-982f-87763285188c
17b3c39a-3832-48be-901d-7354703994fc
mvo5eHmyYxRxH9E9R78tqY
123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ
123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ
0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#$%&'()*+-./:<=>?@[]^_`{|}~
```