### PR TITLE
Patch: ConsistentLength for short.generate()

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,11 @@ let toFlickr;
  * @param {Object} [paddingParams]
  * @returns {string}
  */
-const shortenUUID = (longId, translator, paddingParams) => {
+const shortenUUID = (longId, translator, paddingParams = {
+  consistentLength: true,
+  shortIdLength: 22,
+  paddingChar: '1',
+}) => {
   const translated = translator(longId.toLowerCase().replace(/-/g, ""));
 
   if (!paddingParams || !paddingParams.consistentLength) return translated;


### PR DESCRIPTION
When using the default value for consistentLength as True, the original generate would not return consistent length when you initiate it without a custom alphabet, because it would skip the instantiation of these parameters.

To solve that I started the `shortenUUID` function with default paddingParams. So it would use base params when a custom alphabet is not provided.

This patch should not cause any problems for users that already have been using the new 4.0.1 version.