### PR TITLE
Add UUID type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,10 +33,10 @@ declare module 'short-uuid' {
       uuid(): UUID;
 
       /** short -> long */
-      toUUID(shortId: string): UUID;
+      toUUID(shortId: string | UUID): UUID;
 
       /** long -> short */
-      fromUUID(regularUUID: string): UUID;
+      fromUUID(regularUUID: string | UUID): UUID;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,31 +12,32 @@ declare module 'short-uuid' {
     };
 
     export type UUID = string & { _guidBrand: 'short-uuid' };
+    export type SUUID = string & { _guidBrand: 'uuid' };
 
     /** Generate a new regular UUID. */
     export function uuid(): UUID;
 
     /** Generate a base 58 short uuid */
-    export function generate(): UUID;
+    export function generate(): SUUID;
 
     export interface Translator {
       /** The alphabet used for encoding UUIDs. */
       alphabet: string;
 
       /** Generate a new short UUID using this translator's alphabet. */
-      new: () => UUID;
+      new: () => SUUID;
 
       /** Generate a new short UUID using this translator's alphabet. */
-      generate: () => UUID;
+      generate: () => SUUID;
 
       /** Generate a new regular UUID. */
       uuid(): UUID;
 
       /** short -> long */
-      toUUID(shortId: string | UUID): UUID;
+      toUUID(shortId: string | SUUID): UUID;
 
       /** long -> short */
-      fromUUID(regularUUID: string | UUID): UUID;
+      fromUUID(regularUUID: string | UUID): SUUID;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,30 +11,32 @@ declare module 'short-uuid' {
       cookieBase90: string;
     };
 
+    export type UUID = string & { _guidBrand: 'short-uuid' };
+
     /** Generate a new regular UUID. */
-    export function uuid(): string;
+    export function uuid(): UUID;
 
     /** Generate a base 58 short uuid */
-    export function generate(): string;
+    export function generate(): UUID;
 
     export interface Translator {
       /** The alphabet used for encoding UUIDs. */
       alphabet: string;
 
       /** Generate a new short UUID using this translator's alphabet. */
-      new: () => string;
+      new: () => UUID;
 
       /** Generate a new short UUID using this translator's alphabet. */
-      generate: () => string;
+      generate: () => UUID;
 
       /** Generate a new regular UUID. */
-      uuid(): string;
+      uuid(): UUID;
 
       /** short -> long */
-      toUUID(shortId: string): string;
+      toUUID(shortId: string): UUID;
 
       /** long -> short */
-      fromUUID(regularUUID: string): string;
+      fromUUID(regularUUID: string): UUID;
     }
   }
 


### PR DESCRIPTION
Adding a `UUID` type so we can expect a uuid instead of a string using typescript

```typescript
import uuid, { UUID } from 'short-uuid';

const id = uuid.generate();

create(id); // ok
create('abcd') // error

function create(id: UUID) {
  ...
}
```

This implementation extends string to keep backward compatibility, so this will continue working

```typescript
const id: string = uuid.generate()
```