### PR TITLE
fix: reject an out-of-range id in toUUID instead of silently truncating

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -4,12 +4,21 @@ import type { Config, SUUID, UUID } from './types';
  * Translate back to hex and into UUID format with dashes
  * Pad with zeros if necessary to accommodate unusual IDs
  */
-export const restoreUUID = (config:Config, shortId:SUUID):UUID =>
-  config.hexFromAlphabet(shortId)
-    .padStart(32, '0')
-    .match(/(\w{8})(\w{4})(\w{4})(\w{4})(\w{12})/)
+export const restoreUUID = (config:Config, shortId:SUUID):UUID => {
+  const hex = config.hexFromAlphabet(shortId).padStart(32, '0');
+
+  // An id that decodes to more than 128 bits cannot represent a UUID. Without
+  // this guard the unanchored match below would silently keep the first 32 hex
+  // characters and drop the overflow, returning a wrong UUID.
+  if (hex.length > 32) {
+    throw new Error(`The id "${shortId}" is out of range to represent a UUID.`);
+  }
+
+  return hex
+    .match(/^(\w{8})(\w{4})(\w{4})(\w{4})(\w{12})$/)
     ?.slice(1)
     .join('-') as UUID;
+};
 
 export const shortenUUID = (config:Config, longId:UUID):SUUID => {
   const translated = config.hexToAlphabet(longId.toLowerCase().replace(/-/g, ''));

--- a/test/index.js
+++ b/test/index.js
@@ -139,6 +139,20 @@ test('Handle UUIDs with all "f"s', (t) => {
   t.equal(allFs, b36.toUUID(b36.fromUUID(allFs)), 'Supports all "f"s');
 });
 
+test('should reject an id that is out of range for a UUID', (t) => {
+  t.plan(3);
+
+  // 22 flickrBase58 characters can encode a value larger than 2^128-1, which
+  // cannot be a UUID; this id decodes to more than 32 hex characters.
+  const outOfRange = 'ZZZZZZZZZZZZZZZZZZZZZZ';
+
+  t.throws(() => b58.toUUID(outOfRange), /out of range/, 'toUUID throws instead of silently truncating');
+
+  const valid = b58.fromUUID(crypto.randomUUID());
+  t.doesNotThrow(() => b58.toUUID(valid), 'a valid id does not throw');
+  t.equal(b58.fromUUID(b58.toUUID(valid)), valid, 'a valid id still round-trips');
+});
+
 test('should handle UUID with uppercase letters', (t) => {
   t.plan(4);
 


### PR DESCRIPTION
## Problem

`toUUID` can silently return a wrong UUID. Because `maxLength` is `ceil(128 / log2(alphabetLength))` (rounded up), a maxLength-character id can encode a value larger than `2^128 - 1`. Such an id decodes to more than 32 hex characters, and `restoreUUID`'s unanchored match keeps only the first 32 and drops the overflow:

```js
const short = require('short-uuid');
const t = short.createTranslator(short.constants.flickrBase58); // maxLength 22

const x = 'ZZZZZZZZZZZZZZZZZZZZZZ'; // 22 chars, in-alphabet, decodes to > 2^128-1
t.validate(x);            // true
t.toUUID(x);              // '1d5b20ad-2d23-30b1-0a7b-b82b9f63ffff'  (truncated)
t.fromUUID(t.toUUID(x));  // '4CfuZZZZZZZZZZZZZZZZZZ'  !== x
```

This breaks the documented `toUUID` / `fromUUID` round-trip. `validate(x, true)` (rigorous) already returns `false` for these ids, so the library treats them as invalid, yet `toUUID` accepts and corrupts them.

## Cause

`src/translate.ts`:

```ts
export const restoreUUID = (config, shortId) =>
  config.hexFromAlphabet(shortId)
    .padStart(32, '0')
    .match(/(\w{8})(\w{4})(\w{4})(\w{4})(\w{12})/)  // unanchored: matches first 32 hex
    ?.slice(1)
    .join('-');
```

When the decoded hex is longer than 32 characters the overflow is silently discarded.

## Fix

Guard the decoded length and throw (matching the library's existing behaviour of throwing on invalid input, e.g. a duplicate-character alphabet), and anchor the match so the 32-hex expectation is explicit. Normal ids (<= 2^128-1) are unaffected.

## Tests

Added a case asserting `toUUID` throws on an out-of-range id and that a normally generated id still round-trips. It fails on `develop` (the id silently truncates) and passes with the fix. Full suite green (195 tests).